### PR TITLE
Modify the tutorial steps on the README.md file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,21 @@ using Actions on Google.
 1. Click on the gear icon to see the project settings.
 1. Select *Export and Import*.
 1. Select *Restore from zip*. Follow the directions to restore from the `AoG-Tips.zip` file in this repo.
+
+1. Go to the [Google Cloud Platform console](https://console.developers.google.com/apis/api/actions.googleapis.com/overview) to activate the Actions API, and select the project that you have created on the Actions on Google console. Then, click the *Enable* button.
+
 1. Go to the [Firebase console](https://console.firebase.google.com) and select the project that you have created on the Actions on Google console.
 1. Click the gear icon, then select *Project settings* > *SERVICE ACCOUNTS*.
 1. Generate a new private key and save it in the `functions` folder calling the file `service-account.json`.
-1. In the `functions` directory, deploy the fulfillment webhook provided in the functions folder using [Google Cloud Functions for Firebase](https://firebase.google.com/docs/functions/):
-   1. Follow the instructions to [set up and initialize Firebase SDK for Cloud Functions](https://firebase.google.com/docs/functions/get-started#set_up_and_initialize_functions_sdk). Make sure to select the project that you have previously generated in the Actions on Google Console and to reply `N` when asked to overwrite existing files by the Firebase CLI.
-   1. Run `firebase deploy` and take note of the endpoint where the fulfillment webhook has been published. It should look like `Function URL (aogTips): https://${REGION}-${PROJECT}.cloudfunctions.net/aogTips`
-1. Go back to the Dialogflow console and select *Fulfillment* from the left navigation menu. Enable *Webhook*, set the value of *URL* to the `Function URL` from the previous step, then click *Save*.
-1. Go back to the [Firebase console](https://console.firebase.google.com).
 1. On the left navigation menu under *DEVELOP*, click on *Database*.
 1. Under *Cloud Firebase Beta*, click *Get Started*.
 1. Select *Start in test mode*, click *Enable*.
+
+1. In the `functions` directory, deploy the fulfillment webhook provided in the functions folder using [Google Cloud Functions for Firebase](https://firebase.google.com/docs/functions/):
+   1. Follow the instructions to [set up and initialize Firebase SDK for Cloud Functions](https://firebase.google.com/docs/functions/get-started#set_up_and_initialize_functions_sdk). Make sure to select the project that you have previously generated in the Actions on Google Console and to reply `N` when asked to overwrite existing files by the Firebase CLI.
+   1. Run `npm install` to install dependencies.
+   1. Run `firebase deploy` and take note of the endpoint where the fulfillment webhook has been published. It should look like `Function URL (aogTips): https://${REGION}-${PROJECT}.cloudfunctions.net/aogTips`
+1. Go back to the Dialogflow console and select *Fulfillment* from the left navigation menu. Enable *Webhook*, set the value of *URL* to the `Function URL` from the previous step, then click *Save*.
 
 1. To add tips to the newly created Firestore database, load in a browser `https://${REGION}-${PROJECT}.cloudfunctions.net/restoreTipsDB`.
 1. Go to the [Actions on Google console](https://console.actions.google.com).


### PR DESCRIPTION
In the current README.md file, there are some wrong points to fulfill the tutorial. This pull request provides diffs to fix them.

* To send a push notification, the Actions API must be activated. However, it is not just enough to do the current steps. I would like to add the mention to enable the Actions API on the Google Cloud Platform console at [here](https://github.com/actions-on-google/dialogflow-updates-nodejs/pull/7/files#diff-04c6e90faac2675aa89e2176d2eec7d8R17).

* Before deploying functions from the local machine, the Datastore feature must be activated. I would like to move the steps for the activation of the Datastore before the step to deploy functions (see [here](https://github.com/actions-on-google/dialogflow-updates-nodejs/pull/7/files#diff-04c6e90faac2675aa89e2176d2eec7d8R22)).

* Before running the `firebase deploy` command, all dependencies must be installed. I would like to add the step to install dependencies at [here](https://github.com/actions-on-google/dialogflow-updates-nodejs/pull/7/files#diff-04c6e90faac2675aa89e2176d2eec7d8R28).